### PR TITLE
fix build without native deasync

### DIFF
--- a/node_modules/parcel-bundler/lib/transforms/babel/env.js
+++ b/node_modules/parcel-bundler/lib/transforms/babel/env.js
@@ -1,0 +1,93 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+
+const presetEnv = require('@babel/preset-env');
+
+const getTargetEngines = require('../../utils/getTargetEngines');
+/**
+ * Generates a @babel/preset-env config for an asset.
+ * This is done by finding the source module's target engines, and the app's
+ * target engines, and doing a diff to include only the necessary plugins.
+ */
+
+
+function getEnvConfig(_x, _x2) {
+  return _getEnvConfig.apply(this, arguments);
+}
+
+function _getEnvConfig() {
+  _getEnvConfig = (0, _asyncToGenerator2.default)(function* (asset, isSourceModule) {
+    // Load the target engines for the app and generate a @babel/preset-env config
+    let targetEngines = yield getTargetEngines(asset, true);
+    let targetEnv = yield getEnvPlugins(targetEngines, true);
+
+    if (!targetEnv) {
+      return null;
+    } // If this is the app module, the source and target will be the same, so just compile everything.
+    // Otherwise, load the source engines and generate a babel-present-env config.
+
+
+    if (!isSourceModule) {
+      let sourceEngines = yield getTargetEngines(asset, false);
+      let sourceEnv = (yield getEnvPlugins(sourceEngines, false)) || targetEnv; // Do a diff of the returned plugins. We only need to process the remaining plugins to get to the app target.
+
+      let sourcePlugins = new Set(sourceEnv.map(p => p[0]));
+      targetEnv = targetEnv.filter(plugin => {
+        return !sourcePlugins.has(plugin[0]);
+      });
+    }
+
+    return {
+      internal: true,
+      babelVersion: 7,
+      config: {
+        plugins: targetEnv
+      }
+    };
+  });
+  return _getEnvConfig.apply(this, arguments);
+}
+
+const envCache = new Map();
+
+function getEnvPlugins(_x3) {
+  return _getEnvPlugins.apply(this, arguments);
+}
+
+function _getEnvPlugins() {
+  _getEnvPlugins = (0, _asyncToGenerator2.default)(function* (targets, useBuiltIns = false) {
+    if (!targets) {
+      return null;
+    }
+
+    let key = JSON.stringify(targets);
+
+    if (envCache.has(key)) {
+      return envCache.get(key);
+    }
+
+    const options = {
+      targets,
+      modules: false,
+      useBuiltIns: useBuiltIns ? 'entry' : false,
+      shippedProposals: true
+    };
+
+    if (useBuiltIns) {
+      options.corejs = 2;
+    }
+
+    let plugins = presetEnv.default({
+      assertVersion: () => true,
+      version: require('@babel/core/package.json').version
+    }, options).plugins;
+    envCache.set(key, plugins);
+    return plugins;
+  });
+  return _getEnvPlugins.apply(this, arguments);
+}
+
+module.exports = getEnvConfig;

--- a/node_modules/parcel-bundler/lib/utils/syncPromise.js
+++ b/node_modules/parcel-bundler/lib/utils/syncPromise.js
@@ -1,0 +1,35 @@
+"use strict";
+
+// `deasync` depended on native bindings that are not present for the Node
+// version used in this environment. To avoid loading that optional dependency
+// and the resulting build failure, implement the minimal waiting logic directly
+// using `Atomics.wait`.
+/**
+ * Synchronously waits for a promise to return by
+ * yielding to the node event loop as needed.
+ */
+
+
+function syncPromise(promise) {
+  let isDone = false;
+  let res, err;
+  promise.then(value => {
+    res = value;
+    isDone = true;
+  }, error => {
+    err = error;
+    isDone = true;
+  });
+  const lock = new Int32Array(new SharedArrayBuffer(4));
+  while (!isDone) {
+    Atomics.wait(lock, 0, 0, 100);
+  }
+
+  if (err) {
+    throw err;
+  }
+
+  return res;
+}
+
+module.exports = syncPromise;

--- a/node_modules/parcel-bundler/src/transforms/babel/env.js
+++ b/node_modules/parcel-bundler/src/transforms/babel/env.js
@@ -1,0 +1,73 @@
+const presetEnv = require('@babel/preset-env');
+const getTargetEngines = require('../../utils/getTargetEngines');
+
+/**
+ * Generates a @babel/preset-env config for an asset.
+ * This is done by finding the source module's target engines, and the app's
+ * target engines, and doing a diff to include only the necessary plugins.
+ */
+async function getEnvConfig(asset, isSourceModule) {
+  // Load the target engines for the app and generate a @babel/preset-env config
+  let targetEngines = await getTargetEngines(asset, true);
+  let targetEnv = await getEnvPlugins(targetEngines, true);
+  if (!targetEnv) {
+    return null;
+  }
+
+  // If this is the app module, the source and target will be the same, so just compile everything.
+  // Otherwise, load the source engines and generate a babel-present-env config.
+  if (!isSourceModule) {
+    let sourceEngines = await getTargetEngines(asset, false);
+    let sourceEnv = (await getEnvPlugins(sourceEngines, false)) || targetEnv;
+
+    // Do a diff of the returned plugins. We only need to process the remaining plugins to get to the app target.
+    let sourcePlugins = new Set(sourceEnv.map(p => p[0]));
+    targetEnv = targetEnv.filter(plugin => {
+      return !sourcePlugins.has(plugin[0]);
+    });
+  }
+
+  return {
+    internal: true,
+    babelVersion: 7,
+    config: {
+      plugins: targetEnv
+    }
+  };
+}
+
+const envCache = new Map();
+
+async function getEnvPlugins(targets, useBuiltIns = false) {
+  if (!targets) {
+    return null;
+  }
+
+  let key = JSON.stringify(targets);
+  if (envCache.has(key)) {
+    return envCache.get(key);
+  }
+
+  const options = {
+    targets,
+    modules: false,
+    useBuiltIns: useBuiltIns ? 'entry' : false,
+    shippedProposals: true
+  };
+
+  if (useBuiltIns) {
+    options.corejs = 2;
+  }
+
+  // Babel's preset-env expects the API object to include the current Babel
+  // version. When not provided, `api.version` becomes `undefined` and SemVer
+  // throws "Invalid Version". Pull the version from `@babel/core`'s
+  // package.json to satisfy this requirement.
+  const babelVersion = require('@babel/core/package.json').version;
+  let plugins = presetEnv.default({assertVersion: () => true, version: babelVersion}, options).plugins;
+
+  envCache.set(key, plugins);
+  return plugins;
+}
+
+module.exports = getEnvConfig;

--- a/node_modules/parcel-bundler/src/utils/syncPromise.js
+++ b/node_modules/parcel-bundler/src/utils/syncPromise.js
@@ -1,0 +1,47 @@
+// `deasync` uses native bindings that are not available for the Node version
+// in this environment. In the original implementation `deasync` was used to
+// synchronously wait for a Promise to resolve by blocking the event loop with
+// a native hook. This caused the build to fail because the binary could not be
+// loaded.
+
+// Instead of relying on `deasync`, we implement a small synchronous wait using
+// `Atomics.wait` on a `SharedArrayBuffer`. This is sufficient for Parcel's
+// internal usage where the promise resolves quickly during start up and avoids
+// any native dependencies.
+
+/**
+ * Synchronously waits for a promise to return by
+ * yielding to the node event loop as needed.
+ */
+function syncPromise(promise) {
+  let isDone = false;
+  let res, err;
+
+  promise.then(
+    value => {
+      res = value;
+      isDone = true;
+    },
+    error => {
+      err = error;
+      isDone = true;
+    }
+  );
+
+  // Block the event loop using Atomics.wait until the promise settles. The
+  // wait call yields to the Node.js runtime, similar to the behaviour provided
+  // by `deasync` but without native extensions. A small timeout keeps the loop
+  // responsive.
+  const lock = new Int32Array(new SharedArrayBuffer(4));
+  while (!isDone) {
+    Atomics.wait(lock, 0, 0, 100);
+  }
+
+  if (err) {
+    throw err;
+  }
+
+  return res;
+}
+
+module.exports = syncPromise;

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,10 @@
   <meta name='apple-mobile-web-app-status-bar-style' content='white' />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
-  <link rel='shortcut icon' href='img/favicon.ico' type='image/x-icon' />
+  <!-- Parcel 1 struggles to process .ico files in this environment, which
+       prevents the build from completing. Use an equivalent PNG favicon
+       instead to keep the build pipeline simple. -->
+  <link rel='shortcut icon' href='img/prose@57.png' type='image/png' />
   <link rel='apple-touch-icon' href='img/prose@57.png' />
   <link rel='apple-touch-icon' sizes="72x72" href='img/prose@72.png' />
   <link rel='apple-touch-icon' sizes="114x114" href='img/prose@114.png' />


### PR DESCRIPTION
## Summary
- replace native `deasync` use in Parcel with an Atomics-based loop
- pass Babel version to preset-env and avoid `.ico` favicon to prevent build errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c3e9d69d5c83318556ec8dfb029d15