### PR TITLE
Fix style-loader dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sass-loader": "^16.0.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.6.0",
-    "style-loader": "^4.4.0",
+    "style-loader": "^3.3.4",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.1.0"


### PR DESCRIPTION
## Summary
- fix the dev dependency on style-loader to use the latest 3.x release available on npm

## Testing
- npm install --no-progress *(fails with 403 Forbidden when contacting the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cb683ab3b08331b1e1f5649f9f5a8e