### PR TITLE
Fix build by replacing node path dependency and loading txt templates

### DIFF
--- a/src/scripts/models/file.js
+++ b/src/scripts/models/file.js
@@ -5,7 +5,7 @@ import {
 } from 'lodash-es';
 import { t } from '../translations';
 
-import pathUtil from 'path';
+import pathUtil from '../path-util';
 
 import marked from 'marked';
 // import Backbone from 'backbone';

--- a/src/scripts/path-util.js
+++ b/src/scripts/path-util.js
@@ -1,0 +1,36 @@
+export const join = (...segments) => {
+  if (!segments.length) return '';
+
+  const parts = [];
+
+  segments.forEach((segment, index) => {
+    if (segment == null) {
+      return;
+    }
+
+    let part = String(segment);
+    if (!part) {
+      return;
+    }
+
+    if (index > 0) {
+      part = part.replace(/^\/+/, '');
+    }
+
+    if (index < segments.length - 1) {
+      part = part.replace(/\/+$/, '');
+    }
+
+    if (part) {
+      parts.push(part);
+    }
+  });
+
+  if (!parts.length) {
+    return '';
+  }
+
+  return parts.join('/').replace(/\/{2,}/g, '/');
+};
+
+export default { join };

--- a/src/scripts/views/header.js
+++ b/src/scripts/views/header.js
@@ -1,4 +1,4 @@
-import pathUtil from 'path';
+import pathUtil from '../path-util';
 
 import Backbone from 'backbone';
 import { escape, template, extend } from 'lodash-es';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,10 @@ module.exports = (env, argv) => {
           ],
         },
         {
+          test: /\.txt$/,
+          type: 'asset/source',
+        },
+        {
           test: /\.(png|jpe?g|gif|svg)$/i,
           type: 'asset/resource',
           generator: {


### PR DESCRIPTION
## Summary
- replace usage of Node's `path` module with a small browser-friendly helper and update imports
- teach webpack to load `.txt` template files so template imports compile again

## Testing
- npm run build *(fails: webpack not found in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cb7c64ab588331a92f750577bfb191