### PR TITLE
Configure Buffer polyfill for webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = (env, argv) => {
     },
     resolve: {
       extensions: ['.js'],
+      fallback: {
+        buffer: require.resolve('buffer/'),
+      },
     },
     module: {
       rules: [
@@ -71,6 +74,9 @@ module.exports = (env, argv) => {
       }),
       new MiniCssExtractPlugin({
         filename: isProduction ? 'assets/css/[name].[contenthash:8].css' : 'assets/css/[name].css',
+      }),
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
       }),
       new webpack.DefinePlugin({
         'process.env': JSON.stringify({


### PR DESCRIPTION
## Summary
- add a webpack resolve fallback to provide the browser-friendly buffer implementation
- inject Buffer globally via ProvidePlugin so modules that rely on Node's Buffer continue to work under webpack 5

## Testing
- npm run build *(fails: webpack binary not present in repo-provided node_modules)*

------
https://chatgpt.com/codex/tasks/task_b_68cbb6242564833182404e40743c7af0