### PR TITLE
Add buffer dependency for webpack polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deepmerge": "^2.0.1",
     "diff": "~2.2.0",
     "handsontable": "8.0.0",
+    "buffer": "^6.0.3",
     "ignore": "^3.3.7",
     "jquery": "^3.5.1",
     "jquery-browserify": "~1.8.1",


### PR DESCRIPTION
## Summary
- add the `buffer` package to dependencies so webpack's Buffer polyfill can be resolved

## Testing
- `npm run build` *(fails: webpack binary missing because development dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cbbb31d8808331b08be07288ddcf82