### PR TITLE
refactor: update sass imports

### DIFF
--- a/deprecated/style/_codemirror.scss
+++ b/deprecated/style/_codemirror.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/codemirror/lib/codemirror';
+@import '../node_modules/codemirror/lib/codemirror.css';
 
 .CodeMirror {
   font-family: Menlo, monospace;

--- a/deprecated/style/style.scss
+++ b/deprecated/style/style.scss
@@ -1,11 +1,11 @@
 @charset "utf-8";
 
-@import 'reset';
-@import 'font';
-@import 'type';
+@use './reset' as *;
+@use './font' as *;
+@use './type' as *;
 
 // TODO main is still a giant blob of everything
 // this should also be split up into more manageable chunks.
-@import 'main';
-@import 'codemirror';
-@import 'responsive';
+@use './main' as *;
+@use './codemirror' as *;
+@use './responsive' as *;

--- a/src/style/_codemirror.scss
+++ b/src/style/_codemirror.scss
@@ -1,4 +1,4 @@
-@import '../../node_modules/codemirror/lib/codemirror';
+@import '../../node_modules/codemirror/lib/codemirror.css';
 
 .CodeMirror {
   font-family: Menlo, monospace;

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -1,11 +1,11 @@
 @charset "utf-8";
 
-@import 'reset';
-@import 'font';
-@import 'type';
+@use './reset' as *;
+@use './font' as *;
+@use './type' as *;
 
 // TODO main is still a giant blob of everything
 // this should also be split up into more manageable chunks.
-@import 'main';
-@import 'codemirror';
-@import 'responsive';
+@use './main' as *;
+@use './codemirror' as *;
+@use './responsive' as *;


### PR DESCRIPTION
## Summary
- replace deprecated Sass @import statements in the main and deprecated stylesheets with module-friendly @use includes to avoid loader warnings
- ensure the CodeMirror stylesheet import targets the CSS asset explicitly so bundlers can resolve it without errors

## Testing
- node_modules/.bin/sass src/style/style.scss /tmp/style.css
- node_modules/.bin/sass deprecated/style/style.scss /tmp/dep-style.css

------
https://chatgpt.com/codex/tasks/task_b_68cbc7761b608331aab887fb1ceb3584