### PR TITLE
Convert scripts to ES module exports

### DIFF
--- a/src/scripts/collections/branches.js
+++ b/src/scripts/collections/branches.js
@@ -6,7 +6,7 @@ import {
 import Branch from '../models/branch';
 import util from '../util';
 
-module.exports = Backbone.Collection.extend({
+const Branches = Backbone.Collection.extend({
   model: Branch,
 
   initialize(models, options) {
@@ -46,3 +46,5 @@ module.exports = Backbone.Collection.extend({
     return `${this.repo.url()}/branches?per_page=100`;
   },
 });
+
+export default Branches;

--- a/src/scripts/collections/commits.js
+++ b/src/scripts/collections/commits.js
@@ -3,7 +3,7 @@ import Backbone from 'backbone';
 import { map, extend } from 'lodash-es';
 import Commit from '../models/commit';
 
-module.exports = Backbone.Collection.extend({
+const Commits = Backbone.Collection.extend({
   model: Commit,
 
   initialize: function(models, options) {
@@ -27,3 +27,5 @@ module.exports = Backbone.Collection.extend({
     return this.repo.url() + '/commits?sha=' + this.branch;
   }
 });
+
+export default Commits;

--- a/src/scripts/collections/files.js
+++ b/src/scripts/collections/files.js
@@ -33,7 +33,7 @@ function replacePlaceholders (placeholderValues, initialValue) {
   return result;
 }
 
-module.exports = Backbone.Collection.extend({
+const Files = Backbone.Collection.extend({
   model: function(attributes, options) {
     // TODO: handle 'symlink' and 'submodule' type
     // TODO: coerce tree/folder to a single type
@@ -340,3 +340,5 @@ module.exports = Backbone.Collection.extend({
     };
   }
 });
+
+export default Files;

--- a/src/scripts/collections/orgs.js
+++ b/src/scripts/collections/orgs.js
@@ -6,7 +6,7 @@ import Org from '../models/org';
 import { Config } from '../config';
 import { cookie } from '../storage/cookie';
 
-module.exports = Backbone.Collection.extend({
+const Orgs = Backbone.Collection.extend({
   model: Org,
 
   initialize: function(models, options) {
@@ -31,3 +31,5 @@ module.exports = Backbone.Collection.extend({
     }
   }
 });
+
+export default Orgs;

--- a/src/scripts/collections/repos.js
+++ b/src/scripts/collections/repos.js
@@ -10,7 +10,7 @@ import { cookie } from '../storage/cookie';
 
 import util from '../util';
 
-module.exports = Backbone.Collection.extend({
+const Repos = Backbone.Collection.extend({
   model: Repo,
 
   initialize: function(models, options) {
@@ -62,3 +62,5 @@ module.exports = Backbone.Collection.extend({
     return Config.api + path + '/repos?per_page=100';
   }
 });
+
+export default Repos;

--- a/src/scripts/collections/users.js
+++ b/src/scripts/collections/users.js
@@ -3,6 +3,8 @@ import Backbone from 'backbone';
 // import { Config } from '../config';
 import { User } from '../models/user';
 
-module.exports = Backbone.Collection.extend({
+const Users = Backbone.Collection.extend({
   model: User
 });
+
+export default Users;

--- a/src/scripts/models/branch.js
+++ b/src/scripts/models/branch.js
@@ -2,7 +2,7 @@ import Backbone from 'backbone';
 import Files from '../collections/files';
 import { Config } from '../config';
 
-module.exports = Backbone.Model.extend({
+const BranchModel = Backbone.Model.extend({
   initialize: function(attributes, options) {
     this.repo = attributes.repo;
 
@@ -22,3 +22,5 @@ module.exports = Backbone.Model.extend({
     return this.repo.url() + '/branches/' + this.get('name');
   }
 });
+
+export default BranchModel;

--- a/src/scripts/models/commit.js
+++ b/src/scripts/models/commit.js
@@ -1,7 +1,7 @@
 
 import Backbone from 'backbone';
 
-module.exports = Backbone.Model.extend({
+const CommitModel = Backbone.Model.extend({
   initialize: function(attributes, options) {
     this.repo = attributes.repo;
   },
@@ -10,3 +10,5 @@ module.exports = Backbone.Model.extend({
     return this.repo.url() + '/commits/' + this.get('sha');
   }
 });
+
+export default CommitModel;

--- a/src/scripts/models/file.js
+++ b/src/scripts/models/file.js
@@ -12,7 +12,7 @@ import marked from 'marked';
 var jsyaml = require('js-yaml');
 import util from '../util';
 
-module.exports = Backbone.Model.extend({
+const FileModel = Backbone.Model.extend({
   idAttribute: 'path',
 
   initialize: function(attributes, options) {
@@ -281,7 +281,7 @@ module.exports = Backbone.Model.extend({
 
                 // Create new File model in forked repo
                 // TODO: serialize metadata, set raw content
-                var file = new module.exports({
+                var file = new FileModel({
                   branch: branch,
                   collection: collection,
                   content: this.get('content'),
@@ -382,3 +382,5 @@ module.exports = Backbone.Model.extend({
     });
   }
 });
+
+export default FileModel;

--- a/src/scripts/models/folder.js
+++ b/src/scripts/models/folder.js
@@ -3,7 +3,7 @@
 import Backbone from 'backbone';
 import util from '.././util';
 
-module.exports = Backbone.Model.extend({
+const FolderModel = Backbone.Model.extend({
   idAttribute: 'path',
 
   initialize: function(attributes, options) {
@@ -22,3 +22,5 @@ module.exports = Backbone.Model.extend({
     return this.repo.url() + '/contents/' + this.get('path') + '?ref=' + this.branch.get('name');
   }
 });
+
+export default FolderModel;

--- a/src/scripts/models/org.js
+++ b/src/scripts/models/org.js
@@ -1,5 +1,7 @@
 // import Backbone from 'backbone';
 import Backbone from 'backbone';
 
-module.exports = Backbone.Model.extend({
+const OrgModel = Backbone.Model.extend({
 });
+
+export default OrgModel;

--- a/src/scripts/models/repo.js
+++ b/src/scripts/models/repo.js
@@ -7,7 +7,7 @@ import Branches from '../collections/branches';
 import Commits from '../collections/commits';
 import { Config } from '../config';
 
-module.exports = Backbone.Model.extend({
+const RepoModel = Backbone.Model.extend({
   constructor: function(attributes, options) {
     Backbone.Model.call(this, {
       id: attributes.id,
@@ -56,8 +56,7 @@ module.exports = Backbone.Model.extend({
       url: this.url() + '/forks',
       success: (function(res) {
         // Initialize new Repo model
-        // TODO: is referencing module.exports in this manner acceptable?
-        var repo = new module.exports(res);
+        var repo = new RepoModel(res);
 
         // TODO: Forking is async, retry if request fails
         repo.branches.fetch({
@@ -87,3 +86,5 @@ module.exports = Backbone.Model.extend({
     return url;
   }
 });
+
+export default RepoModel;

--- a/src/scripts/router/index.js
+++ b/src/scripts/router/index.js
@@ -61,7 +61,7 @@ function newRepo(user, repoName) {
   });
 }
 
-module.exports = Backbone.Router.extend({
+const Router = Backbone.Router.extend({
 
   routes: {
     'about(/)': 'about',
@@ -406,3 +406,5 @@ module.exports = Backbone.Router.extend({
     this.notify(message, error, options);
   },
 });
+
+export default Router;

--- a/src/scripts/translations/locales.js
+++ b/src/scripts/translations/locales.js
@@ -158,4 +158,4 @@ const locales = [{
   'code': 'vi-VN'
 }];
 
-module.exports = locales;
+export default locales;

--- a/src/scripts/translations/update_locales.js
+++ b/src/scripts/translations/update_locales.js
@@ -48,7 +48,7 @@ function getResource(resource, callback) {
       callback(null, locale);
     });
 
-    fs.writeFileSync('translations/locales.js', '// Automatically Generated\n\nmodule.exports = ' + JSON.stringify(lang) + ';');
+    fs.writeFileSync('translations/locales.js', '// Automatically Generated\n\nconst locales = ' + JSON.stringify(lang) + ';\n\nexport default locales;\n');
   });
 }
 

--- a/src/scripts/upload.js
+++ b/src/scripts/upload.js
@@ -1,4 +1,4 @@
-module.exports = {
+const upload = {
     dragEnter: function(e) {
         $(e.currentTarget).addClass('drag-over');
         e.stopPropagation();
@@ -69,3 +69,5 @@ module.exports = {
         }
     }
 };
+
+export default upload;

--- a/src/scripts/util.js
+++ b/src/scripts/util.js
@@ -4,7 +4,7 @@ import { all, includes, map, clone, isFunction } from 'lodash-es';
 // import templates from './templates';
 import chrono from 'chrono';
 
-module.exports = {
+const util = {
 
     // Cleans up a string for use in urls
     stringToUrl: function(string) {
@@ -299,3 +299,5 @@ module.exports = {
         }
     }
 };
+
+export default util;

--- a/src/scripts/views/toolbar/markdown.js
+++ b/src/scripts/views/toolbar/markdown.js
@@ -1,6 +1,6 @@
 import { t } from '../../translations';
 
-module.exports = function() {
+export default function() {
   return {
     help: [{
       menuName: t('dialogs.help.blockElements.title'),
@@ -57,4 +57,4 @@ module.exports = function() {
     }
     ]
   };
-};
+}


### PR DESCRIPTION
## Summary
- replace CommonJS `module.exports` usage across utilities, collections, models, router, and toolbar helpers with default ES module exports
- adjust the translations generator to emit the new export format so regenerated files keep the same shape

## Testing
- `npm run build` *(fails: webpack binary missing in environment and dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_b_68cbd822a8308331be4fc4c59c45f30a