### PR TITLE
Fix lodash-es imports in scripts

### DIFF
--- a/src/scripts/models/file.js
+++ b/src/scripts/models/file.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import {
   omit, pick, extend, clone, isFunction, isUndefined,
-  map, pairs
+  map, toPairs
 } from 'lodash-es';
 import { t } from '../translations';
 
@@ -346,7 +346,7 @@ const FileModel = Backbone.Model.extend({
     };
 
     var url = this.url().split('?')[0];
-    var params = map(pairs(data), function(param) { return param.join('='); }).join('&');
+    var params = map(toPairs(data), function(param) { return param.join('='); }).join('&');
 
     Backbone.Model.prototype.destroy.call(this, extend(options, {
       url: url + '?' + params,

--- a/src/scripts/util.js
+++ b/src/scripts/util.js
@@ -1,6 +1,6 @@
 
 
-import { all, includes, map, clone, isFunction } from 'lodash-es';
+import { every, includes, map, clone, isFunction } from 'lodash-es';
 // import templates from './templates';
 import chrono from 'chrono';
 
@@ -33,7 +33,7 @@ const util = {
 
     validPathname: function(path) {
         var regex = /^([a-zA-Z0-9_\-]|\.)+$/;
-        return all(path.split('/'), function(filename) {
+        return every(path.split('/'), function(filename) {
             return !!regex.test(filename);
         });
     },

--- a/src/scripts/views/file.js
+++ b/src/scripts/views/file.js
@@ -7,7 +7,7 @@ import 'codemirror/mode/javascript/javascript';
 
 import { Liquid } from 'liquidjs';
 import {
-  template, compact, has, delay, map, pairs, invoke, escape, extend,
+  template, compact, has, delay, map, toPairs, invoke, escape, extend,
 } from 'lodash-es';
 import { queue } from 'd3-queue';
 import Handsontable from 'handsontable';
@@ -1290,7 +1290,7 @@ export default class FileView extends Backbone.View {
             branch: this.collection.branch.get('name'),
           };
 
-          params = map(pairs(data), (param) => param.join('=')).join('&');
+          params = map(toPairs(data), (param) => param.join('=')).join('&');
 
           $.ajax({
             type: 'DELETE',

--- a/src/scripts/views/metadata.js
+++ b/src/scripts/views/metadata.js
@@ -3,7 +3,7 @@ import CodeMirror from 'codemirror';
 import merge from 'deepmerge';
 import {
   bindAll, template, extend, isArray, difference, union,
-  chain, pluck, forEach, find, filter, invoke,
+  chain, map, forEach, find, filter, invoke,
 } from 'lodash-es';
 
 // var chosen = require('chosen-jquery-browserify');
@@ -123,7 +123,7 @@ export default class MetaDataView extends Backbone.View {
     })).groupBy('name').forEach((group) => {
       const { name } = group[0];
       metadata[name] = group.length === 1
-        ? group[0].value : pluck(group, 'value');
+        ? group[0].value : map(group, 'value');
     });
 
     // TODO does this always default metadata.published to true?


### PR DESCRIPTION
## Summary
- replace usages of removed lodash-es helpers with supported equivalents
- update metadata view to collect grouped values without relying on pluck

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68cbdbefc3008331baa2e9f997ce6b5b