### PR TITLE
Fix webpack dev server start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "lint": "eslint src/scripts/**/*.js --fix",
     "build": "webpack --mode production",
-    "start": "webpack serve --mode development --open false --port 3000"
+    "start": "webpack serve --mode development --port 3000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- remove the invalid `--open false` flag from the webpack dev server start script to rely on the configuration value

## Testing
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_b_68ccc5b24dbc83319dd41f02ffe5347e