### PR TITLE
Fix translations helper to use function expression

### DIFF
--- a/src/scripts/translations/index.js
+++ b/src/scripts/translations/index.js
@@ -69,7 +69,7 @@ locale.current = function(_) {
  * @param  {[type]} loc locale
  * @return {[type]}     [description]
  */
-export const t = (s, o, loc) => {
+export const t = function t(s, o, loc) {
   if (!arguments.length) return;
   loc = loc || locale._current;
 


### PR DESCRIPTION
## Summary
- replace the arrow function in the translation helper with a classic function so that `arguments` is defined when the function executes in the browser

## Testing
- npm run lint *(fails: existing lint violations throughout legacy codebase)*

------
https://chatgpt.com/codex/tasks/task_b_68cccb44facc8331adb6159b730c0f3d