### PR TITLE
build: allow local oauth overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Prose supports configuration settings with a variety of options, which makes it 
 
 Prose is hosted at [Prose.io](http://prose.io), or you can use on your own server. For installation instructions and contributing guidelines, please [read contributing.md](CONTRIBUTING.md). For deploying to your own server, read [deployment.md](DEPLOYMENT.md).
 
+#### Local OAuth configuration for development
+
+When running `npm run start`, you can override OAuth-related values without affecting production builds by creating a `site/oauth.json.local` file. Use the same shape as [`site/oauth.json`](site/oauth.json), for example:
+
+```json
+{
+  "api": "https://api.github.com",
+  "site": "https://github.com",
+  "clientId": "your-local-client-id",
+  "gatekeeperUrl": "http://localhost:9999"
+}
+```
+
+Any keys provided in this file will be injected into `process.env` during development so that modules like [`src/scripts/config.js`](src/scripts/config.js) receive the overridden values.
+
 ### Getting help
 
 Have questions? Jump into the #prose channel on irc.freenode.net.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -6,6 +7,26 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = (env, argv) => {
   const isProduction = argv.mode === 'production';
+
+  const localOAuthPath = path.resolve(__dirname, 'site/oauth.json.local');
+  let localOAuthConfig = {};
+
+  if (!isProduction && fs.existsSync(localOAuthPath)) {
+    try {
+      const raw = fs.readFileSync(localOAuthPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      localOAuthConfig = {
+        API_URL: parsed.api,
+        STATUS_URL: parsed.statusUrl,
+        SITE_URL: parsed.site,
+        OAUTH_CLIENT_ID: parsed.clientId,
+        GATEKEEPER_HOST: parsed.gatekeeperUrl,
+      };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to read site/oauth.json.local:', error);
+    }
+  }
 
   return {
     entry: path.resolve(__dirname, 'src/scripts/app.js'),
@@ -81,11 +102,11 @@ module.exports = (env, argv) => {
       new webpack.DefinePlugin({
         'process.env': JSON.stringify({
           NODE_ENV: process.env.NODE_ENV || (isProduction ? 'production' : 'development'),
-          API_URL: process.env.API_URL || '',
-          STATUS_URL: process.env.STATUS_URL || '',
-          SITE_URL: process.env.SITE_URL || '',
-          OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID || '',
-          GATEKEEPER_HOST: process.env.GATEKEEPER_HOST || '',
+          API_URL: process.env.API_URL || localOAuthConfig.API_URL || '',
+          STATUS_URL: process.env.STATUS_URL || localOAuthConfig.STATUS_URL || '',
+          SITE_URL: process.env.SITE_URL || localOAuthConfig.SITE_URL || '',
+          OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID || localOAuthConfig.OAUTH_CLIENT_ID || '',
+          GATEKEEPER_HOST: process.env.GATEKEEPER_HOST || localOAuthConfig.GATEKEEPER_HOST || '',
         }),
       }),
       new CopyWebpackPlugin({


### PR DESCRIPTION
## Summary
- load `site/oauth.json.local` during development to hydrate the OAuth-related environment variables
- document how to opt into local OAuth overrides without impacting production builds

## Testing
- `npm run lint` *(fails: existing lint issues in the repository unrelated to this change)*
- `npm run build` *(fails: webpack package unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccf009f418833189c4ca14bec37f94