### PR TITLE
metadata: replace chain usage in getValue

### DIFF
--- a/src/scripts/views/metadata.js
+++ b/src/scripts/views/metadata.js
@@ -3,7 +3,7 @@ import CodeMirror from 'codemirror';
 import merge from 'deepmerge';
 import {
   bindAll, template, extend, isArray, difference, union,
-  chain, map, forEach, find, filter, invoke,
+  map, forEach, find, filter, invoke, groupBy,
 } from 'lodash-es';
 
 // var chosen = require('chosen-jquery-browserify');
@@ -111,17 +111,17 @@ export default class MetaDataView extends Backbone.View {
   }
 
   getValue = () => {
-    const view = this;
     let metadata = this.model.get('metadata') || {};
 
     // It's important to save only the data that's represented
     // by the current meta elements.
     // Even if there are elements with the same name.
-    chain(this.subviews).map((view) => ({
-      value: view.getValue(),
-      name: view.name,
-    })).groupBy('name').forEach((group) => {
-      const { name } = group[0];
+    const groupedValues = groupBy(this.subviews.map((subview) => ({
+      value: subview.getValue(),
+      name: subview.name,
+    })), 'name');
+
+    forEach(groupedValues, (group, name) => {
       metadata[name] = group.length === 1
         ? group[0].value : map(group, 'value');
     });


### PR DESCRIPTION
## Summary
- replace the metadata view's use of `_.chain` in `getValue` with direct mapping and grouping logic
- import `groupBy` from lodash-es and remove the unused `chain` helper

## Testing
- `npm run lint` *(fails: existing lint errors across legacy files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68cd15342c108331992d04882c1c48bf